### PR TITLE
Disable uci runloop

### DIFF
--- a/src/engine.cc
+++ b/src/engine.cc
@@ -335,7 +335,7 @@ void EngineLoop::RunLoop() {
   const auto options = options_.GetOptionsDict();
   Logging::Get().SetFilename(options.Get<std::string>(kLogFileId));
   if (options.Get<bool>(kPreload)) engine_.NewGame();
-  UciLoop::RunLoop();
+//  UciLoop::RunLoop();
 }
 
 void EngineLoop::CmdUci() {


### PR DESCRIPTION
* Disable UCI runloop since Swift package does not communicate via command line input